### PR TITLE
feat(pre-adhan): add per-prayer pre-reminder (minutes + audio)

### DIFF
--- a/src/components/DropDown.js
+++ b/src/components/DropDown.js
@@ -3,7 +3,7 @@ import { AppContext } from '../AppContext';
 
 export default function DropDown(props) {
 
-    const { updateSettings, calculationSettings, azanSettings, deviceSettings, offsetSettings } = useContext(AppContext)
+    const { updateSettings, calculationSettings, azanSettings, deviceSettings, offsetSettings, preReminderEnabled, preReminderMinutes, preReminderAudio } = useContext(AppContext)
 
     function updateValue(e) {
         let settingName = e.target.name.split('.')[0];

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -3,7 +3,7 @@ import { AppContext } from '../AppContext';
 
 export default function Options(props) {
 
-    const { updateSettings, calculationSettings, azanSettings, deviceSettings, offsetSettings } = useContext(AppContext)
+    const { updateSettings, calculationSettings, azanSettings, deviceSettings, offsetSettings, preReminderEnabled, preReminderMinutes, preReminderAudio } = useContext(AppContext)
 
     function updateValue(v) {
         let settingName = props.name.split('.')[0];

--- a/src/data/DefaultSettings.js
+++ b/src/data/DefaultSettings.js
@@ -5,6 +5,10 @@ export const DefaultSettings = {
     calculationSettings: { method: 'ISNA', asrMethod: 'S' },
     deviceSettings: { azanCallsEnabled: 'Y', mode: 'N' },
     azanSettings: { fajr: '13', dhuhr: '7', asr: '9', maghrib: '6', isha: '3' },
+    // Pre-Adhan reminder settings
+    preReminderEnabled: { fajr: 'N', dhuhr: 'N', asr: 'N', maghrib: 'N', isha: 'N' },
+    preReminderMinutes: { fajr: 10, dhuhr: 10, asr: 10, maghrib: 10, isha: 10 },
+    preReminderAudio: { fajr: '102', dhuhr: '102', asr: '102', maghrib: '102', isha: '102' },
     offsetSettings: { fajr: 0, dhuhr: 0, asr: 0, maghrib: 0, isha: 0 },
     alarmSettings: [],
     naflAlarmSettings: [],

--- a/src/scripts/SmartAzanClock.js
+++ b/src/scripts/SmartAzanClock.js
@@ -14,7 +14,7 @@ export const SmartAzanClock = {
     colors: { black: 'black', white: 'whitesmoke' },
     getPrayerTime(vakit) { return this.prayerTimes[vakit].replace(/^0/, ''); },
     run(info) {
-
+        
         //console.log('SmartAzanClock.run: ' + (info ?? ''))
 
         let storedSettings = JSON.parse(localStorage.getItem('settings'));
@@ -133,11 +133,27 @@ export const SmartAzanClock = {
             this.output.background = '';
         }
 
+        // On-time adhan
         if (this.currentTimeString === this.currentVakit.time && this.settings.deviceSettings.azanCallsEnabled === 'Y') {
             let cvakit = this.currentVakit.name.toLowerCase();
             if (this.settings.azanSettings[cvakit]) {
                 let aaID = this.settings.azanSettings[cvakit] * 1;
                 setAAA(aaID, this.currentTimeString);
+            }
+        }
+
+        // Pre-adhan reminder for configured prayers
+        const prayers = ['Fajr', 'Dhuhr', 'Asr', 'Maghrib', 'Isha'];
+        for (let p of prayers) {
+            const key = p.toLowerCase();
+            const enabled = (this.settings.preReminderEnabled && this.settings.preReminderEnabled[key]) === 'Y';
+            if (!enabled) continue;
+            const minutes = (this.settings.preReminderMinutes && this.settings.preReminderMinutes[key]) ?? 10;
+            const audioId = (this.settings.preReminderAudio && this.settings.preReminderAudio[key]) || '102';
+            const vakitTime = this.getPrayerTime(key);
+            const reminderTime = addMinutesToTime(vakitTime, -1 * (minutes * 1));
+            if (this.currentTimeString === reminderTime && this.settings.deviceSettings.azanCallsEnabled === 'Y') {
+                setAAA(audioId * 1, reminderTime);
             }
         }
 


### PR DESCRIPTION
- Settings UI: On/Off, audio select, preview, numeric minutes (0–180) with responsive layout\n- Default settings: preReminderEnabled/minutes/audio per prayer\n- Engine: trigger reminders X minutes before vakit in SmartAzanClock\n- i18n: hook now applies language changes instantly via CustomEvent